### PR TITLE
Provide a sensible default path for package main sugar case

### DIFF
--- a/package-name-map/src/package-name-map.ts
+++ b/package-name-map/src/package-name-map.ts
@@ -266,7 +266,10 @@ const findPackage = (
     if (scope.packages) {
       for (const [pkgName, pkg] of Object.entries(scope.packages)) {
         if (isPathSegmentPrefix(pkgName, specifier)) {
-          foundPackage = typeof pkg === 'string' ? {main: pkg} : pkg;
+          foundPackage = typeof pkg === 'string' ? {
+            main: pkg,
+            path: pkg.substr(0, pkg.lastIndexOf('/')) || undefined
+          } : pkg;
           foundPackageName = pkgName;
           break;
         }

--- a/package-name-map/src/test/package-name-map_test.ts
+++ b/package-name-map/src/test/package-name-map_test.ts
@@ -144,7 +144,7 @@ suite('PackageNameMap', () => {
             moment: {
               main: 'http://moment.com/moment.js'
             },
-            '@polymer/polymer': 'index.js',
+            '@polymer/polymer': '/dist/polymer/index.js',
             '@polymer/polymer-foo': {
               main: '../polymer-foo.js'
             }
@@ -180,7 +180,11 @@ suite('PackageNameMap', () => {
       });
 
       test('supports relative main sugar', () => {
-        assert.equal(map.resolve('@polymer/polymer', referrerURL), 'http://foo.com/node_modules/@polymer/polymer/index.js');
+        assert.equal(map.resolve('@polymer/polymer', referrerURL), 'http://foo.com/dist/polymer/index.js');
+      });
+
+      test('supports sensible path for relative main sugar', () => {
+        assert.equal(map.resolve('@polymer/polymer/x', referrerURL), 'http://foo.com/dist/polymer/x');
       });
 
       test('supports relative URL main', () => {


### PR DESCRIPTION
The test case here is the following:

```json
  "path_prefix": "/node_modules",
  "packages": {
    "@polymer/polymer": "/dist/polymer/index.js",
  }
```

where we then test `resolve('@polymer/polymer')` as well as `require('@polymer/polymer/x')`.

The first case of the main resolution remains the same, but the second case is changed to provide a more sensible path default of the folder of the main used in the main sugar.

This way we get, with this new test:

```js
// Before the code change:
resolve('@polymer/polymer')    // -> "http://foo.com/dist/polymer/index.js"
resolve('@polymer/polymer/x') // -> "http://foo.com/node_modules/@polymer/polymer/x"

// After the code change:
resolve('@polymer/polymer')    // -> "http://foo.com/dist/polymer/index.js"
resolve('@polymer/polymer/x') // -> "http://foo.com/dist/polymer/x"
```

I've found in testing out the usage in practical scenarios that this helps to keep the package boundary well-defined and in line with intuition.