### PR TITLE
doc: fix main entry point in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Consider a UI widget, distributed under the "package name" `widget`. It contains
 ```json
 {
   "imports": {
-    "widget/": "/node_modules/widget/index.mjs",
+    "widget": "/node_modules/widget/index.mjs",
     "widget/": "/node_modules/widget/"
   }
 }


### PR DESCRIPTION
If I read above correctly the main entry point shouldn't have a trailing slash