### PR TITLE
Warn on missing trailing slashes in targets

### DIFF
--- a/reference-implementation/__tests__/helpers/parsing.js
+++ b/reference-implementation/__tests__/helpers/parsing.js
@@ -1,15 +1,40 @@
 'use strict';
 const { parseFromString } = require('../../lib/parser.js');
 
-exports.expectSpecifierMap = (input, baseURL, output) => {
-  expect(parseFromString(`{ "imports": ${input} }`, baseURL))
+function testWarningHandler(expectWarnings) {
+  if (typeof expectWarnings === 'string')
+    expectWarnings = [expectWarnings];
+  const warnings = [];
+  return {
+    warn (warning) {
+      warnings.push(warning);
+    },
+    checkWarnings () {
+      warnings.forEach((warning, index) => expect(warning).toEqual(expectWarnings[index]));
+      if (warnings.length > expectWarnings.length)
+        expect(warnings[expectWarnings.length]).toEqual(undefined);
+      else if (expectWarnings.length > warnings.length)
+        expect(undefined).toEqual(expectWarnings[warnings.length]);
+    }
+  };
+}
+
+exports.expectSpecifierMap = (input, baseURL, output, warnings = []) => {
+  const { warn, checkWarnings } = testWarningHandler(warnings);
+
+  expect(parseFromString(`{ "imports": ${input} }`, baseURL, warn))
     .toEqual({ imports: output, scopes: {} });
 
-  expect(parseFromString(`{ "scopes": { "https://scope.example/":  ${input} } }`, baseURL))
+  // warnings should be identical to the above, so skipped here
+  expect(parseFromString(`{ "scopes": { "https://scope.example/":  ${input} } }`, baseURL, () => {}))
     .toEqual({ imports: {}, scopes: { 'https://scope.example/': output } });
+
+  checkWarnings();
 };
 
-exports.expectScopes = (inputArray, baseURL, outputArray) => {
+exports.expectScopes = (inputArray, baseURL, outputArray, warnings = []) => {
+  const { warn, checkWarnings } = testWarningHandler(warnings);
+
   const inputScopesAsStrings = inputArray.map(scopePrefix => `"${scopePrefix}": {}`);
   const inputString = `{ "scopes": { ${inputScopesAsStrings.join(', ')} } }`;
 
@@ -18,9 +43,13 @@ exports.expectScopes = (inputArray, baseURL, outputArray) => {
     outputScopesObject[outputScopePrefix] = {};
   }
 
-  expect(parseFromString(inputString, baseURL)).toEqual({ imports: {}, scopes: outputScopesObject });
+  expect(parseFromString(inputString, baseURL, warn)).toEqual({ imports: {}, scopes: outputScopesObject });
+
+  checkWarnings();
 };
 
-exports.expectBad = (input, baseURL) => {
-  expect(() => parseFromString(input, baseURL)).toThrow(TypeError);
+exports.expectBad = (input, baseURL, warnings = []) => {
+  const { warn, checkWarnings } = testWarningHandler(warnings);
+  expect(() => parseFromString(input, baseURL, warn)).toThrow(TypeError);
+  checkWarnings();
 };

--- a/reference-implementation/__tests__/helpers/parsing.js
+++ b/reference-implementation/__tests__/helpers/parsing.js
@@ -1,20 +1,14 @@
 'use strict';
 const { parseFromString } = require('../../lib/parser.js');
 
-function testWarningHandler(expectWarnings) {
-  if (typeof expectWarnings === 'string')
-    expectWarnings = [expectWarnings];
+function testWarningHandler(expectedWarnings) {
   const warnings = [];
   return {
-    warn (warning) {
+    warn(warning) {
       warnings.push(warning);
     },
-    checkWarnings () {
-      warnings.forEach((warning, index) => expect(warning).toEqual(expectWarnings[index]));
-      if (warnings.length > expectWarnings.length)
-        expect(warnings[expectWarnings.length]).toEqual(undefined);
-      else if (expectWarnings.length > warnings.length)
-        expect(undefined).toEqual(expectWarnings[warnings.length]);
+    checkWarnings() {
+      expect(warnings).toEqual(expectedWarnings);
     }
   };
 }

--- a/reference-implementation/__tests__/parsing-addresses.js
+++ b/reference-implementation/__tests__/parsing-addresses.js
@@ -224,12 +224,10 @@ describe('Absolute URL addresses', () => {
   describe('Failing addresses', () => {
     it('should warn on trailing slash specifier keys not mapping to a trailing slash address', () => {
       expectSpecifierMap(`{
-        "trailer/": ["/notrailer", "dat://s9df80s9d8f"]
+        "trailer/": ["/notrailer"]
       }`, 'https://base.example/path1/path2/path3', {
-        "trailer/": []
-      }, [
-        "Invalid target address https://base.example/notrailer for package specifier 'trailer/'. Package address targets must end with '/'."
-      ]);
+        'trailer/': []
+      }, ['Invalid target address https://base.example/notrailer for package specifier \'trailer/\'. Package address targets must end with \'/\'.']);
     });
   });
 });

--- a/reference-implementation/__tests__/parsing-addresses.js
+++ b/reference-implementation/__tests__/parsing-addresses.js
@@ -227,7 +227,7 @@ describe('Absolute URL addresses', () => {
         "trailer/": ["/notrailer"]
       }`, 'https://base.example/path1/path2/path3', {
         'trailer/': []
-      }, ['Invalid target address https://base.example/notrailer for package specifier \'trailer/\'. Package address targets must end with \'/\'.']);
+      }, [`Invalid target address "https://base.example/notrailer" for package specifier "trailer/". Package address targets must end with "/".`]);
     });
   });
 });

--- a/reference-implementation/__tests__/parsing-addresses.js
+++ b/reference-implementation/__tests__/parsing-addresses.js
@@ -220,4 +220,16 @@ describe('Absolute URL addresses', () => {
       }
     );
   });
+
+  describe('Failing addresses', () => {
+    it('should warn on trailing slash specifier keys not mapping to a trailing slash address', () => {
+      expectSpecifierMap(`{
+        "trailer/": ["/notrailer", "dat://s9df80s9d8f"]
+      }`, 'https://base.example/path1/path2/path3', {
+        "trailer/": []
+      }, [
+        "Invalid target address https://base.example/notrailer for package specifier 'trailer/'. Package address targets must end with '/'."
+      ]);
+    });
+  });
 });

--- a/reference-implementation/__tests__/parsing-specifier-keys.js
+++ b/reference-implementation/__tests__/parsing-specifier-keys.js
@@ -21,15 +21,15 @@ describe('Relative URL-like specifier keys', () => {
   it('should absolutize the literal strings ./, ../, or / with no suffix', () => {
     expectSpecifierMap(
       `{
-        "./": "/dotslash",
-        "../": "/dotdotslash",
-        "/": "/slash"
+        "./": "/dotslash/",
+        "../": "/dotdotslash/",
+        "/": "/slash/"
       }`,
       'https://base.example/path1/path2/path3',
       {
-        'https://base.example/path1/path2/': [expect.toMatchURL('https://base.example/dotslash')],
-        'https://base.example/path1/': [expect.toMatchURL('https://base.example/dotdotslash')],
-        'https://base.example/': [expect.toMatchURL('https://base.example/slash')]
+        'https://base.example/path1/path2/': [expect.toMatchURL('https://base.example/dotslash/')],
+        'https://base.example/path1/': [expect.toMatchURL('https://base.example/dotdotslash/')],
+        'https://base.example/': [expect.toMatchURL('https://base.example/slash/')]
       }
     );
   });
@@ -37,8 +37,8 @@ describe('Relative URL-like specifier keys', () => {
   it('should treat percent-encoded variants of ./, ../, or / as bare specifiers', () => {
     expectSpecifierMap(
       `{
-        "%2E/": "/dotSlash1",
-        "%2E%2E/": "/dotDotSlash1",
+        "%2E/": "/dotSlash1/",
+        "%2E%2E/": "/dotDotSlash1/",
         ".%2F": "/dotSlash2",
         "..%2F": "/dotDotSlash2",
         "%2F": "/slash2",
@@ -47,8 +47,8 @@ describe('Relative URL-like specifier keys', () => {
       }`,
       'https://base.example/path1/path2/path3',
       {
-        '%2E/': [expect.toMatchURL('https://base.example/dotSlash1')],
-        '%2E%2E/': [expect.toMatchURL('https://base.example/dotDotSlash1')],
+        '%2E/': [expect.toMatchURL('https://base.example/dotSlash1/')],
+        '%2E%2E/': [expect.toMatchURL('https://base.example/dotDotSlash1/')],
         '.%2F': [expect.toMatchURL('https://base.example/dotSlash2')],
         '..%2F': [expect.toMatchURL('https://base.example/dotDotSlash2')],
         '%2F': [expect.toMatchURL('https://base.example/slash2')],
@@ -68,9 +68,9 @@ describe('Absolute URL addresses', () => {
         "data:good": "/data",
         "file:///good": "/file",
         "filesystem:good": "/filesystem",
-        "http://good/": "/http",
-        "https://good/": "/https",
-        "ftp://good/": "/ftp",
+        "http://good/": "/http/",
+        "https://good/": "/https/",
+        "ftp://good/": "/ftp/",
         "import:bad": "/import",
         "mailto:bad": "/mailto",
         "javascript:bad": "/javascript",
@@ -83,9 +83,9 @@ describe('Absolute URL addresses', () => {
         'data:good': [expect.toMatchURL('https://base.example/data')],
         'file:///good': [expect.toMatchURL('https://base.example/file')],
         'filesystem:good': [expect.toMatchURL('https://base.example/filesystem')],
-        'http://good/': [expect.toMatchURL('https://base.example/http')],
-        'https://good/': [expect.toMatchURL('https://base.example/https')],
-        'ftp://good/': [expect.toMatchURL('https://base.example/ftp')],
+        'http://good/': [expect.toMatchURL('https://base.example/http/')],
+        'https://good/': [expect.toMatchURL('https://base.example/https/')],
+        'ftp://good/': [expect.toMatchURL('https://base.example/ftp/')],
         'import:bad': [expect.toMatchURL('https://base.example/import')],
         'mailto:bad': [expect.toMatchURL('https://base.example/mailto')],
         'javascript:bad': [expect.toMatchURL('https://base.example/javascript')],
@@ -97,24 +97,24 @@ describe('Absolute URL addresses', () => {
   it('should parse absolute URLs, treating unparseable ones as bare specifiers', () => {
     expectSpecifierMap(
       `{
-        "https://ex ample.org/": "/unparseable1",
+        "https://ex ample.org/": "/unparseable1/",
         "https://example.com:demo": "/unparseable2",
-        "http://[www.example.com]/": "/unparseable3",
-        "https:example.org": "/invalidButParseable1",
-        "https://///example.com///": "/invalidButParseable2",
-        "https://example.net": "/prettyNormal",
-        "https://ex%41mple.com/": "/percentDecoding",
+        "http://[www.example.com]/": "/unparseable3/",
+        "https:example.org": "/invalidButParseable1/",
+        "https://///example.com///": "/invalidButParseable2/",
+        "https://example.net": "/prettyNormal/",
+        "https://ex%41mple.com/": "/percentDecoding/",
         "https://example.com/%41": "/noPercentDecoding"
       }`,
       'https://base.example/path1/path2/path3',
       {
-        'https://ex ample.org/': [expect.toMatchURL('https://base.example/unparseable1')],
+        'https://ex ample.org/': [expect.toMatchURL('https://base.example/unparseable1/')],
         'https://example.com:demo': [expect.toMatchURL('https://base.example/unparseable2')],
-        'http://[www.example.com]/': [expect.toMatchURL('https://base.example/unparseable3')],
-        'https://example.org/': [expect.toMatchURL('https://base.example/invalidButParseable1')],
-        'https://example.com///': [expect.toMatchURL('https://base.example/invalidButParseable2')],
-        'https://example.net/': [expect.toMatchURL('https://base.example/prettyNormal')],
-        'https://example.com/': [expect.toMatchURL('https://base.example/percentDecoding')],
+        'http://[www.example.com]/': [expect.toMatchURL('https://base.example/unparseable3/')],
+        'https://example.org/': [expect.toMatchURL('https://base.example/invalidButParseable1/')],
+        'https://example.com///': [expect.toMatchURL('https://base.example/invalidButParseable2/')],
+        'https://example.net/': [expect.toMatchURL('https://base.example/prettyNormal/')],
+        'https://example.com/': [expect.toMatchURL('https://base.example/percentDecoding/')],
         'https://example.com/%41': [expect.toMatchURL('https://base.example/noPercentDecoding')]
       }
     );

--- a/reference-implementation/__tests__/resolving.js
+++ b/reference-implementation/__tests__/resolving.js
@@ -153,8 +153,8 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
         "/lib/no.mjs": null,
         "./dotrelative/no.mjs": [],
 
-        "/": "/lib/slash-only.mjs/",
-        "./": "/lib/dotslash-only.mjs/",
+        "/": "/lib/slash-only/",
+        "./": "/lib/dotslash-only/",
 
         "/test": "/lib/test1.mjs",
         "../test": "/lib/test2.mjs"
@@ -190,13 +190,13 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
     });
 
     it('should remap URLs that are just composed from / and .', () => {
-      expect(resolveUnderTest('https://example.com/')).toMatchURL('https://example.com/lib/slash-only.mjs/');
-      expect(resolveUnderTest('/')).toMatchURL('https://example.com/lib/slash-only.mjs/');
-      expect(resolveUnderTest('../')).toMatchURL('https://example.com/lib/slash-only.mjs/');
+      expect(resolveUnderTest('https://example.com/')).toMatchURL('https://example.com/lib/slash-only/');
+      expect(resolveUnderTest('/')).toMatchURL('https://example.com/lib/slash-only/');
+      expect(resolveUnderTest('../')).toMatchURL('https://example.com/lib/slash-only/');
 
-      expect(resolveUnderTest('https://example.com/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
-      expect(resolveUnderTest('/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
-      expect(resolveUnderTest('../app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
+      expect(resolveUnderTest('https://example.com/app/')).toMatchURL('https://example.com/lib/dotslash-only/');
+      expect(resolveUnderTest('/app/')).toMatchURL('https://example.com/lib/dotslash-only/');
+      expect(resolveUnderTest('../app/')).toMatchURL('https://example.com/lib/dotslash-only/');
     });
 
     it('should use the last entry\'s address when URL-like specifiers parse to the same absolute URL', () => {

--- a/reference-implementation/__tests__/resolving.js
+++ b/reference-implementation/__tests__/resolving.js
@@ -153,8 +153,8 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
         "/lib/no.mjs": null,
         "./dotrelative/no.mjs": [],
 
-        "/": "/lib/slash-only.mjs",
-        "./": "/lib/dotslash-only.mjs",
+        "/": "/lib/slash-only.mjs/",
+        "./": "/lib/dotslash-only.mjs/",
 
         "/test": "/lib/test1.mjs",
         "../test": "/lib/test2.mjs"
@@ -190,13 +190,13 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
     });
 
     it('should remap URLs that are just composed from / and .', () => {
-      expect(resolveUnderTest('https://example.com/')).toMatchURL('https://example.com/lib/slash-only.mjs');
-      expect(resolveUnderTest('/')).toMatchURL('https://example.com/lib/slash-only.mjs');
-      expect(resolveUnderTest('../')).toMatchURL('https://example.com/lib/slash-only.mjs');
+      expect(resolveUnderTest('https://example.com/')).toMatchURL('https://example.com/lib/slash-only.mjs/');
+      expect(resolveUnderTest('/')).toMatchURL('https://example.com/lib/slash-only.mjs/');
+      expect(resolveUnderTest('../')).toMatchURL('https://example.com/lib/slash-only.mjs/');
 
-      expect(resolveUnderTest('https://example.com/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs');
-      expect(resolveUnderTest('/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs');
-      expect(resolveUnderTest('../app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs');
+      expect(resolveUnderTest('https://example.com/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
+      expect(resolveUnderTest('/app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
+      expect(resolveUnderTest('../app/')).toMatchURL('https://example.com/lib/dotslash-only.mjs/');
     });
 
     it('should use the last entry\'s address when URL-like specifiers parse to the same absolute URL', () => {

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -5,7 +5,7 @@ const { tryURLParse, hasFetchScheme, tryURLLikeSpecifierParse } = require('./uti
 // Tentative, so better to centralize so we can change in one place as necessary (including tests).
 exports.BUILT_IN_MODULE_PREFIX = '@std/';
 
-exports.parseFromString = (input, baseURL, warn = warning => console.warn(warning)) => {
+exports.parseFromString = (input, baseURL) => {
   const parsed = JSON.parse(input);
 
   if (!isJSONObject(parsed)) {
@@ -22,7 +22,7 @@ exports.parseFromString = (input, baseURL, warn = warning => console.warn(warnin
 
   let normalizedImports = {};
   if ('imports' in parsed) {
-    normalizedImports = normalizeSpecifierMap(parsed.imports, baseURL, warn);
+    normalizedImports = normalizeSpecifierMap(parsed.imports, baseURL);
   }
 
   const normalizedScopes = {};
@@ -42,7 +42,7 @@ exports.parseFromString = (input, baseURL, warn = warning => console.warn(warnin
       }
 
       const normalizedScopePrefix = scopePrefixURL.href;
-      normalizedScopes[normalizedScopePrefix] = normalizeSpecifierMap(specifierMap, baseURL, warn);
+      normalizedScopes[normalizedScopePrefix] = normalizeSpecifierMap(specifierMap, baseURL);
     }
   }
 
@@ -53,7 +53,7 @@ exports.parseFromString = (input, baseURL, warn = warning => console.warn(warnin
   };
 };
 
-function normalizeSpecifierMap(obj, baseURL, warn) {
+function normalizeSpecifierMap(obj, baseURL) {
   // Normalize all entries into arrays
   const result = {};
   for (const [specifierKey, value] of Object.entries(obj)) {
@@ -80,7 +80,7 @@ function normalizeSpecifierMap(obj, baseURL, warn) {
           return false;
         }
         if (key[key.length - 1] === '/' && address.href[address.href.length - 1] !== '/') {
-          warn(`Invalid target address ${address} for package specifier '${key}'. ` +
+          console.warn(`Invalid target address ${address} for package specifier '${key}'. ` +
               `Package address targets must end with '/'.`);
           return false;
         }

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -80,8 +80,8 @@ function normalizeSpecifierMap(obj, baseURL) {
           return false;
         }
         if (key[key.length - 1] === '/' && address.href[address.href.length - 1] !== '/') {
-          console.warn(`Invalid target address ${address} for package specifier '${key}'. ` +
-              `Package address targets must end with '/'.`);
+          console.warn(`Invalid target address "${address}" for package specifier "${key}". ` +
+              `Package address targets must end with "/".`);
           return false;
         }
         return true;

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -5,7 +5,7 @@ const { tryURLParse, hasFetchScheme, tryURLLikeSpecifierParse } = require('./uti
 // Tentative, so better to centralize so we can change in one place as necessary (including tests).
 exports.BUILT_IN_MODULE_PREFIX = '@std/';
 
-exports.parseFromString = (input, baseURL, warn = console.warn.bind(console)) => {
+exports.parseFromString = (input, baseURL, warn = warning => console.warn(warning)) => {
   const parsed = JSON.parse(input);
 
   if (!isJSONObject(parsed)) {
@@ -76,10 +76,12 @@ function normalizeSpecifierMap(obj, baseURL, warn) {
     result[key] = addressArray
       .map(address => normalizeAddress(address, baseURL))
       .filter(address => {
-        if (address === null)
+        if (address === null) {
           return false;
+        }
         if (key[key.length - 1] === '/' && address.href[address.href.length - 1] !== '/') {
-          warn(`Invalid target address ${address} for package specifier '${key}'. Package address targets must end with '/'.`);
+          warn(`Invalid target address ${address} for package specifier '${key}'. ` +
+              `Package address targets must end with '/'.`);
           return false;
         }
         return true;


### PR DESCRIPTION
Implements https://github.com/domenic/import-maps/issues/93, along with warning handlers for the tests.

There were a surprising number of tests that failed the warning that needed changing. It can be illustrative to look through these.