### PR TITLE
Scope fetch scheme warnings

### DIFF
--- a/reference-implementation/__tests__/parsing-scope-prefixes.js
+++ b/reference-implementation/__tests__/parsing-scope-prefixes.js
@@ -68,10 +68,10 @@ describe('Absolute URL scope prefixes', () => {
         'ftp://good/'
       ],
       [
-        'Scope import:bad is not using a valid fetch scheme.',
-        'Scope mailto:bad is not using a valid fetch scheme.',
-        'Scope javascript:bad is not using a valid fetch scheme.',
-        'Scope wss://ba/ is not using a valid fetch scheme.'
+        'Invalid scope "import:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "mailto:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "javascript:bad". Scope URLs must have a fetch scheme.',
+        'Invalid scope "wss://ba/". Scope URLs must have a fetch scheme.'
       ]
     );
   });

--- a/reference-implementation/__tests__/parsing-scope-prefixes.js
+++ b/reference-implementation/__tests__/parsing-scope-prefixes.js
@@ -66,6 +66,12 @@ describe('Absolute URL scope prefixes', () => {
         'http://good/',
         'https://good/',
         'ftp://good/'
+      ],
+      [
+        'Scope import:bad is not using a valid fetch scheme.',
+        'Scope mailto:bad is not using a valid fetch scheme.',
+        'Scope javascript:bad is not using a valid fetch scheme.',
+        'Scope wss://ba/ is not using a valid fetch scheme.'
       ]
     );
   });

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -38,6 +38,7 @@ exports.parseFromString = (input, baseURL) => {
       }
 
       if (!hasFetchScheme(scopePrefixURL)) {
+        console.warn(`Scope ${scopePrefixURL} is not using a valid fetch scheme.`);
         continue;
       }
 

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -38,7 +38,7 @@ exports.parseFromString = (input, baseURL) => {
       }
 
       if (!hasFetchScheme(scopePrefixURL)) {
-        console.warn(`Scope ${scopePrefixURL} is not using a valid fetch scheme.`);
+        console.warn(`Invalid scope "${scopePrefixURL}". Scope URLs must have a fetch scheme.`);
         continue;
       }
 


### PR DESCRIPTION
This builds on the PR at https://github.com/domenic/import-maps/pull/95 providing warnings for scope fetch schemes that are ignored.

Ideally the same should happen for the address targets, but that filtering seems to be at resolution time, where `import:` is permitted as well, so may need a bit more careful wiring.